### PR TITLE
feat: Google Analytics 추가

### DIFF
--- a/app/(landing)/_components/LandingContainer.tsx
+++ b/app/(landing)/_components/LandingContainer.tsx
@@ -29,13 +29,13 @@ export default function LandingContainer() {
   };
 
   return (
-    <div className='px-[40px] pt-[70px] pb-[60px] h-screen flex flex-col gap-[24px]'>
+    <div className='px-[40px] pt-[70px] pb-[60px] flex flex-col gap-[24px]'>
       <LandingLogo />
       <LandingContent className='flex flex-col gap-[30px]' isDrawing={isDrawing} />
 
-      <div className={`max-w-[524px] h-[72px] px-[24px]  ${isDrawing && 'invisible'}`}>
+      <div className={`max-w-[524px] px-[24px]  ${isDrawing && 'invisible'}`}>
         <button
-          className='w-full h-full font-semibold text-[24px] text-[#222222] rounded-[20px] bg-gradient-to-r from-[#FFAEAC] to-[#FF7C78]'
+          className='w-full h-[72px] font-semibold text-[24px] text-[#222222] rounded-[20px] bg-gradient-to-r from-[#FFAEAC] to-[#FF7C78]'
           type='button'
           onClick={handleDraw}
         >

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,6 +35,22 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           src={`//dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&libraries=services,clusterer,drawing`}
           strategy='beforeInteractive'
         />
+        <Script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}`}
+        />
+        <Script
+          id='google-analytics'
+          dangerouslySetInnerHTML={{
+            __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', '${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}');
+		        `,
+          }}
+        />
       </head>
       <body className='flex justify-center text-white'>
         <Suspense>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,7 +55,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <body className='flex justify-center text-white'>
         <Suspense>
           <LottoProvider initialData={data}>
-            <div className='min-h-screen w-full max-w-[600px] bg-black pb-[128px]'>{children}</div>
+            <div className='min-h-screen w-full max-w-[600px] bg-black pb-[24px]'>{children}</div>
             <Gnb />
           </LottoProvider>
         </Suspense>

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -73,11 +73,11 @@ export default function MainPage() {
           </div>
         </div>
       </div>
-      <div className='p-[40px] bg-[#383838] flex flex-col gap-[48px]'>
+      <div className='p-[20px] sm:p-[40px] bg-[#383838] flex flex-col gap-[48px]'>
         <h2 className='font-medium text-[20px]'>당첨금으로 뭘 할 수 있을까</h2>
         <div className='flex flex-col gap-[24px]'>
           {purchaseOptions.map((option, index) => (
-            <p key={index} className='text-[24px] font-medium'>
+            <p key={index} className='text-[4vw] sm:text-[24px] font-medium'>
               {option}
             </p>
           ))}
@@ -91,7 +91,7 @@ export default function MainPage() {
         >
           계획 세우러 가기
         </Link>
-        <div className='flex items-center w-full h-[72px] gap-[16px]'>
+        <div className='flex items-center w-full h-[72px] gap-[16px] mb-[92px]'>
           <Link
             className='w-full border-white border-2 rounded-[20px] h-full flex justify-center items-center'
             href={'/article'}

--- a/app/plan/_components/AddedItemList.tsx
+++ b/app/plan/_components/AddedItemList.tsx
@@ -7,7 +7,7 @@ const AddedItemList = () => {
   const items = getItems();
 
   return (
-    <div className='flex justify-center w-full items-center h-[540px] bg-gray'>
+    <div className='flex justify-center w-full items-center h-[480px] bg-gray'>
       {items.length ? (
         <ul className='bg-gray w-full px-10 overflow-y-auto h-full [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-gray [&::-webkit-scrollbar-thumb]:bg-light-gray [&::-webkit-scrollbar-thumb]:rounded-full'>
           {items.map(({ id, name, category, price }) => (

--- a/app/plan/_components/BottomSheet.tsx
+++ b/app/plan/_components/BottomSheet.tsx
@@ -34,7 +34,7 @@ const BottomSheet = () => {
 
   const { addItem } = useItems();
   const { toast } = useToast();
-  
+
   const { lottoData } = useLottoContext();
   const firstWinamnt = lottoData?.firstWinamnt ?? 0;
   const { remainingBudget } = useBudget(firstWinamnt);
@@ -76,7 +76,7 @@ const BottomSheet = () => {
   return (
     <div className='text-center'>
       <Sheet onOpenChange={resetCategory}>
-        <SheetTrigger className='w-full max-w-[476px] h-[72px] rounded-2xl p-2 my-8 bg-gradient-to-r from-main-gradation-start to-main-gradation-end text-black font-bold'>
+        <SheetTrigger className='w-full max-w-[476px] h-[72px] rounded-2xl p-2 my-8 mb-24 bg-gradient-to-r from-main-gradation-start to-main-gradation-end text-black font-bold'>
           아이템 담기
         </SheetTrigger>
 
@@ -106,11 +106,11 @@ const BottomSheet = () => {
                   {items.map((item) => (
                     <span
                       key={item.id}
-                      className='w-full max-w-[520px] h-[92px] flex justify-between items-center border-b-2 border-light-gray text-small cursor-pointer'
+                      className='w-full max-w-[520px] h-[92px] flex justify-between items-center gap-1 border-b-2 border-light-gray text-[16px] sm:text-small cursor-pointer'
                       onClick={() => handleItemClick(item)}
                     >
-                      <span>{item?.name}</span>
-                      <span>{item?.price.toLocaleString()}원</span>
+                      <span className='text-left'>{item?.name}</span>
+                      <span className='text-right'>{item?.price.toLocaleString()}원</span>
                     </span>
                   ))}
                 </span>


### PR DESCRIPTION
## 내용
- GA 추가
- 랜딩 화면 > 처음 접근 시 버튼이 찌부되는 현상 수정 (pc로 처음 열었을 때 아래 이미지처럼 보여서 디자인에 맞게 수정해두었습니다)
<img width="748" alt="image" src="https://github.com/user-attachments/assets/67815722-6b92-4588-8076-fe2ad5027c30">


- 모바일 뷰 사이즈 임시 수정 (디자인 2.0이 나오기 전, 모바일로 접근할 사용자들을 위해 임시 조정해두었습니다. 기존 사이즈는 그대로 두었으며 화면이 작아졌을 때만 변경됩니다)
  - 홈 화면 > '당첨금으로 뭘 할 수 있을까'  아래의 리스트 텍스트 크기 줄이기
  - 계획 화면 > 아이템 담기 소분류 텍스트 크기 줄이기